### PR TITLE
Update supervisord-dashing.conf

### DIFF
--- a/supervisord-dashing.conf
+++ b/supervisord-dashing.conf
@@ -6,4 +6,4 @@ autorestart=true
 command=dashing start
 directory=/dashboard
 autorestart=true
-
+restartasgroup=true


### PR DESCRIPTION
The thin server doesn't stop on shutdown unless restartasgroup=true.
